### PR TITLE
feat: share context between Background and Scenario steps

### DIFF
--- a/.changeset/background-scenario-context-sharing.md
+++ b/.changeset/background-scenario-context-sharing.md
@@ -1,0 +1,27 @@
+---
+'@deepracticex/vitest-cucumber-plugin': minor
+---
+
+Share context between Background and Scenario steps to match Cucumber.js behavior
+
+Background and Scenario steps now share the same ContextManager instance by leveraging Vitest's native context parameter mechanism. This ensures that state set in Background steps is accessible in Scenario steps, matching standard Cucumber.js behavior.
+
+**Changes:**
+
+- Modified `CodeGenerator.generateBackground()` to accept Vitest context and store ContextManager
+- Modified `CodeGenerator.generateScenario()` to reuse ContextManager from context
+- Modified `CodeGenerator.generateScenarioOutline()` to reuse ContextManager from context
+- Added comprehensive tests for context sharing across different scenarios
+
+**Impact:**
+
+- Fixes issue #6: Background steps now properly share state with Scenario steps
+- Reduces learning curve for users familiar with Cucumber.js
+- Eliminates need for workarounds using Before hooks
+- Background now works as expected in standard Cucumber usage patterns
+
+**Migration:**
+
+- Existing tests will continue to work
+- Users who implemented workarounds in Before hooks can now rely on Background
+- No breaking changes to user-facing APIs

--- a/packages/vitest-cucumber-plugin/src/__tests__/background-context-sharing.test.ts
+++ b/packages/vitest-cucumber-plugin/src/__tests__/background-context-sharing.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from 'vitest';
+import { CodeGenerator } from '~/core/transformer/CodeGenerator';
+import type { Feature } from '~/types';
+
+describe('Background Context Sharing', () => {
+  const generator = new CodeGenerator();
+
+  it('should generate code that shares context between Background and Scenario', () => {
+    const feature: Feature = {
+      type: 'Feature',
+      keyword: 'Feature',
+      name: 'User Login',
+      description: '',
+      location: { line: 1, column: 1 },
+      background: {
+        type: 'Background',
+        keyword: 'Background',
+        name: '',
+        description: '',
+        location: { line: 3, column: 3 },
+        steps: [
+          {
+            type: 'Step',
+            keyword: 'Given',
+            text: 'I have initialized the system',
+            location: { line: 4, column: 5 },
+          },
+        ],
+      },
+      scenarios: [
+        {
+          type: 'Scenario',
+          keyword: 'Scenario',
+          name: 'Successful login',
+          description: '',
+          location: { line: 6, column: 3 },
+          isOutline: false,
+          steps: [
+            {
+              type: 'Step',
+              keyword: 'When',
+              text: 'I login with valid credentials',
+              location: { line: 7, column: 5 },
+            },
+          ],
+        },
+      ],
+      rules: [],
+    };
+
+    const code = generator.generate(feature);
+
+    // Verify beforeEach accepts context parameter
+    expect(code).toContain('beforeEach(async (context) => {');
+
+    // Verify Background creates and stores contextManager in vitest context
+    expect(code).toContain('context.contextManager = new ContextManager();');
+
+    // Verify it block accepts context parameter
+    expect(code).toContain("it('Successful login', async (context) => {");
+
+    // Verify Scenario reuses contextManager from vitest context
+    expect(code).toContain(
+      'const contextManager = context.contextManager || new ContextManager();',
+    );
+
+    // Verify executor uses the shared context
+    expect(code).toContain(
+      'const cucumberContext = contextManager.getContext();',
+    );
+    expect(code).toContain(
+      'const executor = new StepExecutor(cucumberContext);',
+    );
+  });
+
+  it('should handle Scenario Outline with shared context', () => {
+    const feature: Feature = {
+      type: 'Feature',
+      keyword: 'Feature',
+      name: 'User Login',
+      description: '',
+      location: { line: 1, column: 1 },
+      background: {
+        type: 'Background',
+        keyword: 'Background',
+        name: '',
+        description: '',
+        location: { line: 3, column: 3 },
+        steps: [
+          {
+            type: 'Step',
+            keyword: 'Given',
+            text: 'the system is ready',
+            location: { line: 4, column: 5 },
+          },
+        ],
+      },
+      scenarios: [
+        {
+          type: 'Scenario',
+          keyword: 'Scenario Outline',
+          name: 'Login with different users',
+          description: '',
+          location: { line: 6, column: 3 },
+          isOutline: true,
+          steps: [
+            {
+              type: 'Step',
+              keyword: 'When',
+              text: 'I login as <user>',
+              location: { line: 7, column: 5 },
+            },
+          ],
+          examples: [
+            {
+              type: 'Examples',
+              keyword: 'Examples',
+              name: '',
+              description: '',
+              location: { line: 9, column: 5 },
+              headers: ['user'],
+              rows: [['admin'], ['guest']],
+            },
+          ],
+        },
+      ],
+      rules: [],
+    };
+
+    const code = generator.generate(feature);
+
+    // Verify beforeEach uses context parameter
+    expect(code).toContain('beforeEach(async (context) => {');
+
+    // Verify example tests accept context parameter
+    expect(code).toMatch(/it\('Example:.*', async \(context\) => \{/);
+
+    // Verify contextManager reuse
+    expect(code).toContain(
+      'const contextManager = context.contextManager || new ContextManager();',
+    );
+  });
+
+  it('should handle Rule with Background context sharing', () => {
+    const feature: Feature = {
+      type: 'Feature',
+      keyword: 'Feature',
+      name: 'User Management',
+      description: '',
+      location: { line: 1, column: 1 },
+      background: {
+        type: 'Background',
+        keyword: 'Background',
+        name: '',
+        description: '',
+        location: { line: 3, column: 3 },
+        steps: [
+          {
+            type: 'Step',
+            keyword: 'Given',
+            text: 'feature-level setup',
+            location: { line: 4, column: 5 },
+          },
+        ],
+      },
+      scenarios: [],
+      rules: [
+        {
+          type: 'Rule',
+          keyword: 'Rule',
+          name: 'Admin operations',
+          description: '',
+          location: { line: 6, column: 3 },
+          background: {
+            type: 'Background',
+            keyword: 'Background',
+            name: '',
+            description: '',
+            location: { line: 7, column: 5 },
+            steps: [
+              {
+                type: 'Step',
+                keyword: 'Given',
+                text: 'rule-level setup',
+                location: { line: 8, column: 7 },
+              },
+            ],
+          },
+          scenarios: [
+            {
+              type: 'Scenario',
+              keyword: 'Scenario',
+              name: 'Create user',
+              description: '',
+              location: { line: 10, column: 5 },
+              isOutline: false,
+              steps: [
+                {
+                  type: 'Step',
+                  keyword: 'When',
+                  text: 'I create a new user',
+                  location: { line: 11, column: 7 },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const code = generator.generate(feature);
+
+    // Both feature-level and rule-level beforeEach should use context parameter
+    const beforeEachMatches = code.match(
+      /beforeEach\(async \(context\) => \{/g,
+    );
+    expect(beforeEachMatches).toBeTruthy();
+    expect(beforeEachMatches!.length).toBeGreaterThanOrEqual(2);
+
+    // Verify context sharing in rule scenarios
+    expect(code).toContain("it('Create user', async (context) => {");
+    expect(code).toContain(
+      'const contextManager = context.contextManager || new ContextManager();',
+    );
+  });
+
+  it('should generate fallback ContextManager when no Background exists', () => {
+    const feature: Feature = {
+      type: 'Feature',
+      keyword: 'Feature',
+      name: 'Simple Feature',
+      description: '',
+      location: { line: 1, column: 1 },
+      scenarios: [
+        {
+          type: 'Scenario',
+          keyword: 'Scenario',
+          name: 'Simple test',
+          description: '',
+          location: { line: 3, column: 3 },
+          isOutline: false,
+          steps: [
+            {
+              type: 'Step',
+              keyword: 'When',
+              text: 'I do something',
+              location: { line: 4, column: 5 },
+            },
+          ],
+        },
+      ],
+      rules: [],
+    };
+
+    const code = generator.generate(feature);
+
+    // Even without Background, Scenario should use context parameter
+    expect(code).toContain("it('Simple test', async (context) => {");
+
+    // Should create new ContextManager if not provided by Background
+    expect(code).toContain(
+      'const contextManager = context.contextManager || new ContextManager();',
+    );
+  });
+});

--- a/packages/vitest-cucumber-plugin/src/core/transformer/CodeGenerator.ts
+++ b/packages/vitest-cucumber-plugin/src/core/transformer/CodeGenerator.ts
@@ -92,16 +92,23 @@ export class CodeGenerator {
     const ind = '  '.repeat(indent);
 
     lines.push('');
-    lines.push(`${ind}it('${this.escapeString(scenario.name)}', async () => {`);
+    lines.push(
+      `${ind}it('${this.escapeString(scenario.name)}', async (context) => {`,
+    );
     lines.push(`${ind}  const hookRegistry = HookRegistry.getInstance();`);
-    lines.push(`${ind}  const contextManager = new ContextManager();`);
-    lines.push(`${ind}  const context = contextManager.getContext();`);
-    lines.push(`${ind}  const executor = new StepExecutor(context);`);
+    lines.push(`${ind}  // Reuse ContextManager from Background if available`);
+    lines.push(
+      `${ind}  const contextManager = context.contextManager || new ContextManager();`,
+    );
+    lines.push(`${ind}  const cucumberContext = contextManager.getContext();`);
+    lines.push(`${ind}  const executor = new StepExecutor(cucumberContext);`);
     lines.push('');
 
     // Execute Before hooks
     lines.push(`${ind}  // Execute Before hooks`);
-    lines.push(`${ind}  await hookRegistry.executeHooks('Before', context);`);
+    lines.push(
+      `${ind}  await hookRegistry.executeHooks('Before', cucumberContext);`,
+    );
     lines.push('');
 
     // Generate steps
@@ -112,7 +119,9 @@ export class CodeGenerator {
 
     // Execute After hooks
     lines.push(`${ind}  // Execute After hooks`);
-    lines.push(`${ind}  await hookRegistry.executeHooks('After', context);`);
+    lines.push(
+      `${ind}  await hookRegistry.executeHooks('After', cucumberContext);`,
+    );
 
     lines.push(`${ind}});`);
 
@@ -177,10 +186,13 @@ export class CodeGenerator {
     const ind = '  '.repeat(indent);
 
     lines.push('');
-    lines.push(`${ind}beforeEach(async () => {`);
-    lines.push(`${ind}  const contextManager = new ContextManager();`);
+    lines.push(`${ind}beforeEach(async (context) => {`);
     lines.push(
-      `${ind}  const executor = new StepExecutor(contextManager.getContext());`,
+      `${ind}  // Create shared ContextManager for Background and Scenario`,
+    );
+    lines.push(`${ind}  context.contextManager = new ContextManager();`);
+    lines.push(
+      `${ind}  const executor = new StepExecutor(context.contextManager.getContext());`,
     );
     lines.push('');
 
@@ -255,20 +267,29 @@ export class CodeGenerator {
 
         lines.push('');
         lines.push(
-          `${ind}  it('Example: ${this.escapeString(exampleDesc)}', async () => {`,
+          `${ind}  it('Example: ${this.escapeString(exampleDesc)}', async (context) => {`,
         );
         lines.push(
           `${ind}    const hookRegistry = HookRegistry.getInstance();`,
         );
-        lines.push(`${ind}    const contextManager = new ContextManager();`);
-        lines.push(`${ind}    const context = contextManager.getContext();`);
-        lines.push(`${ind}    const executor = new StepExecutor(context);`);
+        lines.push(
+          `${ind}    // Reuse ContextManager from Background if available`,
+        );
+        lines.push(
+          `${ind}    const contextManager = context.contextManager || new ContextManager();`,
+        );
+        lines.push(
+          `${ind}    const cucumberContext = contextManager.getContext();`,
+        );
+        lines.push(
+          `${ind}    const executor = new StepExecutor(cucumberContext);`,
+        );
         lines.push('');
 
         // Execute Before hooks
         lines.push(`${ind}    // Execute Before hooks`);
         lines.push(
-          `${ind}    await hookRegistry.executeHooks('Before', context);`,
+          `${ind}    await hookRegistry.executeHooks('Before', cucumberContext);`,
         );
         lines.push('');
 
@@ -285,7 +306,7 @@ export class CodeGenerator {
         // Execute After hooks
         lines.push(`${ind}    // Execute After hooks`);
         lines.push(
-          `${ind}    await hookRegistry.executeHooks('After', context);`,
+          `${ind}    await hookRegistry.executeHooks('After', cucumberContext);`,
         );
 
         lines.push(`${ind}  });`);


### PR DESCRIPTION
## Summary

Implements context sharing between Background and Scenario steps by leveraging Vitest's native context parameter mechanism. This matches standard Cucumber.js behavior where Background and Scenario steps share the same World instance.

## Changes

- Modified `CodeGenerator.generateBackground()` to accept Vitest context and store ContextManager
- Modified `CodeGenerator.generateScenario()` to reuse ContextManager from context  
- Modified `CodeGenerator.generateScenarioOutline()` to reuse ContextManager from context
- Added comprehensive tests for context sharing across different scenarios

## Impact

- ✅ Fixes #6: Background steps now properly share state with Scenario steps
- ✅ Reduces learning curve for users familiar with Cucumber.js
- ✅ Eliminates need for workarounds using Before hooks
- ✅ Background now works as expected in standard Cucumber usage patterns

## Technical Approach

The solution uses Vitest's native context parameter mechanism to share the ContextManager instance:

**Before (Broken):**
```typescript
beforeEach(async () => {
  const contextManager = new ContextManager();  // Context A
  // Background steps execute
});

it('Scenario', async () => {
  const contextManager = new ContextManager();  // Context B (different!)
  // Scenario steps execute
});
```

**After (Fixed):**
```typescript
beforeEach(async (context) => {
  context.contextManager = new ContextManager();  // Store in Vitest context
  // Background steps execute
});

it('Scenario', async (context) => {
  const contextManager = context.contextManager;  // Reuse same instance
  // Scenario steps can access Background state
});
```

## Testing

- Added 4 comprehensive test cases covering:
  - Basic Background-Scenario context sharing
  - Scenario Outline with shared context
  - Rules with Background context sharing
  - Fallback when no Background exists
- All existing tests pass
- No breaking changes

## Migration

- Existing tests will continue to work
- Users who implemented workarounds in Before hooks can now rely on Background
- No user-facing API changes required

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)