### PR TITLE
feat: implement feature-scoped registry for memory leak prevention

### DIFF
--- a/.changeset/context-based-registry.md
+++ b/.changeset/context-based-registry.md
@@ -1,0 +1,42 @@
+---
+'@deepracticex/vitest-cucumber': patch
+'@deepracticex/vitest-cucumber-plugin': patch
+---
+
+Implement feature-scoped registry for memory leak prevention
+
+This change introduces feature-scoped registries to prevent memory leaks and ensure worker processes can exit cleanly:
+
+**Key Changes:**
+
+- Each `.feature` file now has its own isolated StepRegistry and HookRegistry
+- Registries are automatically cleaned up after each feature execution
+- Worker processes can now exit properly, preventing the infinite GC loop issue (#16)
+
+**User Impact:**
+
+- **Zero breaking changes**: Existing user code continues to work without modifications
+- Step definitions (`Given/When/Then`) work exactly as before
+- No configuration changes required - just update the package
+
+**Technical Details:**
+
+- Introduced `StepRegistry.createFeatureScoped()` and `HookRegistry.createFeatureScoped()`
+- CodeGenerator now creates feature-scoped registries instead of using global singletons
+- Added intelligent warning system to detect legacy usage patterns
+- Feature context is set during step file loading via `__setCurrentFeatureContext__()`
+
+**Migration:**
+Users only need to update the package - no code changes required:
+
+```bash
+pnpm update @deepracticex/vitest-cucumber
+```
+
+**Deprecation Notice:**
+
+- Direct use of `StepRegistry.getInstance()` outside of feature context is now deprecated
+- Generated code uses feature-scoped registries (`__featureStepRegistry__`, `__featureHookRegistry__`)
+- Legacy global singleton mode is still supported for backward compatibility
+
+This resolves #16 by ensuring worker processes properly clean up and exit after test execution.

--- a/packages/vitest-cucumber-plugin/src/__tests__/CodeGenerator.test.ts
+++ b/packages/vitest-cucumber-plugin/src/__tests__/CodeGenerator.test.ts
@@ -25,7 +25,7 @@ describe('CodeGenerator', () => {
       // Verify Before hooks are executed in beforeEach
       expect(code).toContain('beforeEach(async (context) => {');
       expect(code).toContain(
-        "await hookRegistry.executeHooks('Before', cucumberContext);",
+        "await __featureHookRegistry__.executeHooks('Before', cucumberContext);",
       );
 
       // Verify Before hooks come BEFORE Background step execution
@@ -150,7 +150,7 @@ describe('CodeGenerator', () => {
       // Before hooks should be in beforeEach only
       expect(code).toContain('beforeEach(async (context) => {');
       expect(code).toContain(
-        "await hookRegistry.executeHooks('Before', cucumberContext);",
+        "await __featureHookRegistry__.executeHooks('Before', cucumberContext);",
       );
 
       // Scenario outline it() blocks should NOT have Before hooks

--- a/packages/vitest-cucumber-plugin/src/__tests__/registry-cleanup.test.ts
+++ b/packages/vitest-cucumber-plugin/src/__tests__/registry-cleanup.test.ts
@@ -23,8 +23,8 @@ describe('Registry Cleanup', () => {
       expect(code).toContain('afterAll(async () => {');
 
       // Verify registry cleanup is present
-      expect(code).toContain('StepRegistry.getInstance().clear()');
-      expect(code).toContain('hookRegistry.clear()');
+      expect(code).toContain('__featureStepRegistry__.clear()');
+      expect(code).toContain('__featureHookRegistry__.clear()');
     });
 
     it('should clean up registries after feature with background', () => {
@@ -47,8 +47,8 @@ describe('Registry Cleanup', () => {
 
       // Verify afterAll exists and contains cleanup
       expect(code).toContain('afterAll(async () => {');
-      expect(code).toContain('StepRegistry.getInstance().clear()');
-      expect(code).toContain('hookRegistry.clear()');
+      expect(code).toContain('__featureStepRegistry__.clear()');
+      expect(code).toContain('__featureHookRegistry__.clear()');
     });
 
     it('should clean up registries in correct order (user hooks before registry clear)', () => {
@@ -78,10 +78,10 @@ describe('Registry Cleanup', () => {
         // Find positions
         const userHookIndex = afterAllBlock.indexOf("executeHooks('AfterAll'");
         const stepRegistryClearIndex = afterAllBlock.indexOf(
-          'StepRegistry.getInstance().clear()',
+          '__featureStepRegistry__.clear()',
         );
         const hookRegistryClearIndex = afterAllBlock.indexOf(
-          'hookRegistry.clear()',
+          '__featureHookRegistry__.clear()',
         );
 
         // Verify all exist

--- a/packages/vitest-cucumber/src/__tests__/feature-scoped-registry.test.ts
+++ b/packages/vitest-cucumber/src/__tests__/feature-scoped-registry.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  StepRegistry,
+  __setCurrentFeatureContext__,
+  __getCurrentFeatureContext__,
+} from '~/core/runtime/StepRegistry';
+import { HookRegistry } from '~/core/runtime/HookRegistry';
+
+describe('Feature-scoped Registry', () => {
+  beforeEach(() => {
+    // Clear global registry
+    (globalThis as any).__VITEST_CUCUMBER_STEP_REGISTRY__ = undefined;
+    (globalThis as any).__VITEST_CUCUMBER_HOOK_REGISTRY__ = undefined;
+    // Clear feature context
+    __setCurrentFeatureContext__(null);
+  });
+
+  afterEach(() => {
+    __setCurrentFeatureContext__(null);
+  });
+
+  describe('StepRegistry.createFeatureScoped()', () => {
+    it('should create a new feature-scoped registry instance', () => {
+      const registry1 = StepRegistry.createFeatureScoped();
+      const registry2 = StepRegistry.createFeatureScoped();
+
+      expect(registry1).not.toBe(registry2);
+      expect(registry1.getAll()).toEqual([]);
+      expect(registry2.getAll()).toEqual([]);
+    });
+
+    it('should create registry with isFeatureScoped flag', () => {
+      const registry = StepRegistry.createFeatureScoped();
+
+      // Register a step
+      registry.register({
+        type: 'Given',
+        pattern: 'test pattern',
+        fn: function () {},
+      });
+
+      expect(registry.getAll()).toHaveLength(1);
+    });
+  });
+
+  describe('Feature context isolation', () => {
+    it('should isolate steps between different features', () => {
+      // Feature 1
+      const registry1 = StepRegistry.createFeatureScoped();
+      const hookRegistry1 = HookRegistry.createFeatureScoped();
+
+      __setCurrentFeatureContext__({
+        stepRegistry: registry1,
+        hookRegistry: hookRegistry1,
+      });
+
+      const step1Registry = StepRegistry.getInstance();
+      step1Registry.register({
+        type: 'Given',
+        pattern: 'feature 1 step',
+        fn: function () {},
+      });
+
+      expect(registry1.getAll()).toHaveLength(1);
+
+      // Feature 2
+      const registry2 = StepRegistry.createFeatureScoped();
+      const hookRegistry2 = HookRegistry.createFeatureScoped();
+
+      __setCurrentFeatureContext__({
+        stepRegistry: registry2,
+        hookRegistry: hookRegistry2,
+      });
+
+      const step2Registry = StepRegistry.getInstance();
+      step2Registry.register({
+        type: 'Given',
+        pattern: 'feature 2 step',
+        fn: function () {},
+      });
+
+      // Verify isolation
+      expect(registry1.getAll()).toHaveLength(1);
+      expect(registry2.getAll()).toHaveLength(1);
+      expect(registry1.getAll()[0].pattern).toBe('feature 1 step');
+      expect(registry2.getAll()[0].pattern).toBe('feature 2 step');
+    });
+
+    it('should clean up properly after feature execution', () => {
+      const registry = StepRegistry.createFeatureScoped();
+      const hookRegistry = HookRegistry.createFeatureScoped();
+
+      __setCurrentFeatureContext__({
+        stepRegistry: registry,
+        hookRegistry: hookRegistry,
+      });
+
+      StepRegistry.getInstance().register({
+        type: 'Given',
+        pattern: 'test step',
+        fn: function () {},
+      });
+
+      expect(registry.getAll()).toHaveLength(1);
+
+      // Simulate feature completion
+      registry.clear();
+      __setCurrentFeatureContext__(null);
+
+      expect(registry.getAll()).toHaveLength(0);
+      expect(__getCurrentFeatureContext__()).toBeNull();
+    });
+  });
+
+  describe('Context priority', () => {
+    it('should prioritize feature context over global singleton', () => {
+      // Create global singleton
+      const globalRegistry = StepRegistry.getInstance();
+      globalRegistry.register({
+        type: 'Given',
+        pattern: 'global step',
+        fn: function () {},
+      });
+
+      // Create feature context
+      const featureRegistry = StepRegistry.createFeatureScoped();
+      const hookRegistry = HookRegistry.createFeatureScoped();
+
+      __setCurrentFeatureContext__({
+        stepRegistry: featureRegistry,
+        hookRegistry: hookRegistry,
+      });
+
+      // getInstance should return feature registry
+      const currentRegistry = StepRegistry.getInstance();
+      expect(currentRegistry).toBe(featureRegistry);
+      expect(currentRegistry.getAll()).toHaveLength(0);
+
+      // Register to feature context
+      currentRegistry.register({
+        type: 'Given',
+        pattern: 'feature step',
+        fn: function () {},
+      });
+
+      // Global should be unchanged
+      expect(globalRegistry.getAll()).toHaveLength(1);
+      expect(featureRegistry.getAll()).toHaveLength(1);
+    });
+
+    it('should fall back to global singleton when no feature context', () => {
+      const registry1 = StepRegistry.getInstance();
+      const registry2 = StepRegistry.getInstance();
+
+      expect(registry1).toBe(registry2);
+      expect(globalThis.__VITEST_CUCUMBER_STEP_REGISTRY__).toBeDefined();
+    });
+  });
+
+  describe('Backward compatibility', () => {
+    it('should support legacy global singleton mode', () => {
+      const registry = StepRegistry.getInstance();
+
+      registry.register({
+        type: 'Given',
+        pattern: 'legacy step',
+        fn: function () {},
+      });
+
+      expect(registry.getAll()).toHaveLength(1);
+      expect(globalThis.__VITEST_CUCUMBER_STEP_REGISTRY__).toBe(registry);
+    });
+
+    it('should allow mixing legacy and feature-scoped modes', () => {
+      // Register to global
+      const globalRegistry = StepRegistry.getInstance();
+      globalRegistry.register({
+        type: 'Given',
+        pattern: 'global step',
+        fn: function () {},
+      });
+
+      // Create feature context
+      const featureRegistry = StepRegistry.createFeatureScoped();
+      __setCurrentFeatureContext__({
+        stepRegistry: featureRegistry,
+        hookRegistry: HookRegistry.createFeatureScoped(),
+      });
+
+      // Register to feature
+      StepRegistry.getInstance().register({
+        type: 'Given',
+        pattern: 'feature step',
+        fn: function () {},
+      });
+
+      // Clear context
+      __setCurrentFeatureContext__(null);
+
+      // Should fall back to global
+      const current = StepRegistry.getInstance();
+      expect(current).toBe(globalRegistry);
+      expect(current.getAll()).toHaveLength(1);
+    });
+  });
+});

--- a/packages/vitest-cucumber/src/__tests__/registry-warnings.test.ts
+++ b/packages/vitest-cucumber/src/__tests__/registry-warnings.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  StepRegistry,
+  __setCurrentFeatureContext__,
+  __resetWarningFlag__,
+} from '~/core/runtime/StepRegistry';
+import { HookRegistry } from '~/core/runtime/HookRegistry';
+
+describe('Registry Warning System', () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+  const originalEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Clear global registry
+    (globalThis as any).__VITEST_CUCUMBER_STEP_REGISTRY__ = undefined;
+    (globalThis as any).__VITEST_CUCUMBER_HOOK_REGISTRY__ = undefined;
+    __setCurrentFeatureContext__(null);
+    __resetWarningFlag__();
+    // Set to development mode for warnings
+    process.env.NODE_ENV = 'development';
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+    __setCurrentFeatureContext__(null);
+    __resetWarningFlag__();
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  describe('getInstance() without feature context', () => {
+    it('should warn when getInstance() called without feature context', () => {
+      StepRegistry.getInstance();
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('outside of feature context'),
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('memory leaks'),
+      );
+    });
+
+    it('should NOT warn when getInstance() called within feature context', () => {
+      const featureRegistry = StepRegistry.createFeatureScoped();
+      __setCurrentFeatureContext__({
+        stepRegistry: featureRegistry,
+        hookRegistry: HookRegistry.createFeatureScoped(),
+      });
+
+      StepRegistry.getInstance();
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should warn only once to avoid spam', () => {
+      StepRegistry.getInstance();
+      StepRegistry.getInstance();
+      StepRegistry.getInstance();
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT warn in test environment', () => {
+      process.env.NODE_ENV = 'test';
+
+      StepRegistry.getInstance();
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should NOT warn in production environment', () => {
+      process.env.NODE_ENV = 'production';
+
+      StepRegistry.getInstance();
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Warning flag reset', () => {
+    it('should reset warning flag when entering new feature context', () => {
+      // First call without context - should warn
+      StepRegistry.getInstance();
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+
+      // Enter feature context (resets warning flag)
+      const featureRegistry = StepRegistry.createFeatureScoped();
+      __setCurrentFeatureContext__({
+        stepRegistry: featureRegistry,
+        hookRegistry: HookRegistry.createFeatureScoped(),
+      });
+
+      // Exit feature context
+      __setCurrentFeatureContext__(null);
+
+      // Second call without context - should warn again
+      StepRegistry.getInstance();
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should allow manual reset of warning flag for testing', () => {
+      StepRegistry.getInstance();
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+
+      __resetWarningFlag__();
+
+      StepRegistry.getInstance();
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Step registration warnings', () => {
+    it('should warn when registering to global registry', () => {
+      const globalRegistry = StepRegistry.getInstance();
+
+      // First call triggers getInstance warning
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      consoleWarnSpy.mockClear();
+
+      // Register step
+      globalRegistry.register({
+        type: 'Given',
+        pattern: 'test step',
+        fn: function () {},
+      });
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('global registry'),
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('deprecated'),
+      );
+    });
+
+    it('should NOT warn when registering to feature-scoped registry', () => {
+      const featureRegistry = StepRegistry.createFeatureScoped();
+      __setCurrentFeatureContext__({
+        stepRegistry: featureRegistry,
+        hookRegistry: HookRegistry.createFeatureScoped(),
+      });
+
+      featureRegistry.register({
+        type: 'Given',
+        pattern: 'test step',
+        fn: function () {},
+      });
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should include step pattern in warning message', () => {
+      const globalRegistry = StepRegistry.getInstance();
+      consoleWarnSpy.mockClear();
+
+      globalRegistry.register({
+        type: 'Given',
+        pattern: 'I have {int} items',
+        fn: function () {},
+      });
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('I have {int} items'),
+      );
+    });
+  });
+
+  describe('Duplicate step detection', () => {
+    it('should warn when registering duplicate step pattern', () => {
+      const registry = StepRegistry.createFeatureScoped();
+
+      registry.register({
+        type: 'Given',
+        pattern: 'test pattern',
+        fn: function () {},
+      });
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+      // Register duplicate
+      registry.register({
+        type: 'Given',
+        pattern: 'test pattern',
+        fn: function () {},
+      });
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Duplicate step definition'),
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('test pattern'),
+      );
+    });
+
+    it('should NOT warn for different step types with same pattern', () => {
+      const registry = StepRegistry.createFeatureScoped();
+
+      registry.register({
+        type: 'Given',
+        pattern: 'test pattern',
+        fn: function () {},
+      });
+
+      registry.register({
+        type: 'When',
+        pattern: 'test pattern',
+        fn: function () {},
+      });
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should NOT warn for regex patterns with same source', () => {
+      const registry = StepRegistry.createFeatureScoped();
+
+      registry.register({
+        type: 'Given',
+        pattern: /^test pattern$/,
+        fn: function () {},
+      });
+
+      registry.register({
+        type: 'Given',
+        pattern: /^test pattern$/,
+        fn: function () {},
+      });
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Duplicate'),
+      );
+    });
+  });
+
+  describe('Warning message quality', () => {
+    it('should provide helpful suggestions in warning messages', () => {
+      StepRegistry.getInstance();
+
+      const warningMessage = consoleWarnSpy.mock.calls[0][0];
+
+      expect(warningMessage).toContain('Common causes');
+      expect(warningMessage).toContain('Recommended');
+      expect(warningMessage).toContain('https://');
+    });
+
+    it('should format warnings with clear structure', () => {
+      StepRegistry.getInstance();
+
+      const warningMessage = consoleWarnSpy.mock.calls[0][0];
+
+      expect(warningMessage).toMatch(/⚠️.*\[vitest-cucumber\]/);
+      expect(warningMessage).toContain('\n');
+    });
+  });
+});

--- a/packages/vitest-cucumber/src/core/runtime/StepRegistry.ts
+++ b/packages/vitest-cucumber/src/core/runtime/StepRegistry.ts
@@ -3,6 +3,7 @@ import {
   ParameterTypeConverter,
   type ParameterInfo,
 } from './ParameterTypeConverter';
+import type { HookRegistry } from './HookRegistry';
 
 /**
  * Extended step definition with parameter type information
@@ -12,33 +13,103 @@ export interface ExtendedStepDefinition extends StepDefinition {
   regex: RegExp;
 }
 
-// Use globalThis to ensure single instance across module boundaries
+/**
+ * Feature context for isolation
+ */
+export interface FeatureContext {
+  stepRegistry: StepRegistry;
+  hookRegistry: HookRegistry;
+}
+
+// Feature context state (set during step file loading)
+let __CURRENT_FEATURE_CONTEXT__: FeatureContext | null = null;
+let __WARNING_SHOWN__ = false;
+let __REGISTRATION_WARNING_SHOWN__ = false;
+
+// Global type augmentation
 declare global {
   var __VITEST_CUCUMBER_STEP_REGISTRY__: StepRegistry | undefined;
 }
 
 /**
- * Global registry for step definitions
+ * Global registry for step definitions with feature-scoped isolation support
  */
 export class StepRegistry {
   private steps: ExtendedStepDefinition[] = [];
+  private isFeatureScoped: boolean = false;
 
-  private constructor() {}
+  private constructor(isFeatureScoped: boolean = false) {
+    this.isFeatureScoped = isFeatureScoped;
+  }
 
   /**
-   * Get the singleton instance (globally shared across all modules)
+   * Get the singleton instance (with feature context support)
    */
   public static getInstance(): StepRegistry {
-    if (!globalThis.__VITEST_CUCUMBER_STEP_REGISTRY__) {
-      globalThis.__VITEST_CUCUMBER_STEP_REGISTRY__ = new StepRegistry();
+    // Priority 1: Use feature context if available (modern mode)
+    if (__CURRENT_FEATURE_CONTEXT__) {
+      return __CURRENT_FEATURE_CONTEXT__.stepRegistry;
     }
+
+    // Priority 2: Fall back to global singleton (legacy mode)
+    if (!globalThis.__VITEST_CUCUMBER_STEP_REGISTRY__) {
+      globalThis.__VITEST_CUCUMBER_STEP_REGISTRY__ = new StepRegistry(false);
+    }
+
+    // Warn about legacy usage (only in development, only once)
+    if (
+      !__WARNING_SHOWN__ &&
+      process.env.NODE_ENV !== 'test' &&
+      process.env.NODE_ENV !== 'production'
+    ) {
+      __WARNING_SHOWN__ = true;
+      console.warn(
+        '\n⚠️  [vitest-cucumber] Step definitions are being registered outside of feature context.\n' +
+          '   This may cause memory leaks in long-running test suites.\n' +
+          '\n' +
+          '   Common causes:\n' +
+          '   1. Calling StepRegistry.getInstance() at module top-level\n' +
+          '   2. Importing step files outside of generated test code\n' +
+          '\n' +
+          '   Recommended: Use Given/When/Then APIs directly instead of getInstance().\n' +
+          '   See: https://github.com/Deepractice/EnhancedVitest/wiki/Best-Practices\n',
+      );
+    }
+
     return globalThis.__VITEST_CUCUMBER_STEP_REGISTRY__;
+  }
+
+  /**
+   * Create a new feature-scoped registry (called by CodeGenerator)
+   */
+  public static createFeatureScoped(): StepRegistry {
+    return new StepRegistry(true);
   }
 
   /**
    * Register a step definition
    */
   public register(step: StepDefinition): void {
+    // Warn if registering to global registry (legacy mode)
+    if (
+      !this.isFeatureScoped &&
+      !__REGISTRATION_WARNING_SHOWN__ &&
+      process.env.NODE_ENV !== 'test' &&
+      process.env.NODE_ENV !== 'production'
+    ) {
+      __REGISTRATION_WARNING_SHOWN__ = true;
+      console.warn(
+        '\n⚠️  [vitest-cucumber] Step registered to global registry.\n' +
+          '   This is deprecated and may cause issues in future versions.\n' +
+          '\n' +
+          '   Location: ' +
+          step.pattern.toString() +
+          '\n' +
+          '\n' +
+          '   Please ensure your step files are only imported by generated test code.\n',
+      );
+    }
+
     // Extract parameter types and convert to regex if needed
     const parameterTypes = ParameterTypeConverter.extractParameterTypes(
       step.pattern,
@@ -54,6 +125,32 @@ export class StepRegistry {
       parameterTypes,
       regex,
     };
+
+    // Check for duplicates (warn only, don't block)
+    const existing = this.steps.find(
+      (s) =>
+        s.pattern.toString() === step.pattern.toString() &&
+        s.type === step.type,
+    );
+
+    if (
+      existing &&
+      process.env.NODE_ENV !== 'test' &&
+      process.env.NODE_ENV !== 'production'
+    ) {
+      console.warn(
+        '\n⚠️  [vitest-cucumber] Duplicate step definition detected.\n' +
+          '   Type: ' +
+          step.type +
+          '\n' +
+          '   Pattern: ' +
+          step.pattern.toString() +
+          '\n' +
+          '\n' +
+          '   This may indicate that step files are being imported multiple times.\n' +
+          '   Each step should only be defined once.\n',
+      );
+    }
 
     this.steps.push(extendedStep);
   }
@@ -82,7 +179,7 @@ export class StepRegistry {
   }
 
   /**
-   * Clear all registered steps (useful for testing)
+   * Clear all registered steps (useful for testing and cleanup)
    */
   public clear(): void {
     this.steps = [];
@@ -94,4 +191,34 @@ export class StepRegistry {
   public getAll(): ExtendedStepDefinition[] {
     return [...this.steps];
   }
+}
+
+/**
+ * Set current feature context (called by CodeGenerator)
+ * @internal
+ */
+export function __setCurrentFeatureContext__(context: FeatureContext | null) {
+  __CURRENT_FEATURE_CONTEXT__ = context;
+
+  // Reset warning flag when entering new feature context
+  if (context) {
+    __WARNING_SHOWN__ = false;
+  }
+}
+
+/**
+ * Get current feature context (for debugging and testing)
+ * @internal
+ */
+export function __getCurrentFeatureContext__(): FeatureContext | null {
+  return __CURRENT_FEATURE_CONTEXT__;
+}
+
+/**
+ * Reset warning flag (for testing)
+ * @internal
+ */
+export function __resetWarningFlag__() {
+  __WARNING_SHOWN__ = false;
+  __REGISTRATION_WARNING_SHOWN__ = false;
 }

--- a/packages/vitest-cucumber/src/core/runtime/index.ts
+++ b/packages/vitest-cucumber/src/core/runtime/index.ts
@@ -1,8 +1,13 @@
 /**
  * Core runtime components
  */
-export { StepRegistry } from './StepRegistry';
-export type { ExtendedStepDefinition } from './StepRegistry';
+export {
+  StepRegistry,
+  __setCurrentFeatureContext__,
+  __getCurrentFeatureContext__,
+  __resetWarningFlag__,
+} from './StepRegistry';
+export type { ExtendedStepDefinition, FeatureContext } from './StepRegistry';
 export { StepExecutor } from './StepExecutor';
 export { ContextManager } from './ContextManager';
 export { DataTable } from './DataTable';


### PR DESCRIPTION
## Summary

Implements feature-scoped registries to prevent memory leaks and ensure worker processes exit cleanly, resolving issue #16.

## Changes

### Key Features
- ✅ Each `.feature` file now has its own isolated `StepRegistry` and `HookRegistry`
- ✅ Registries are automatically cleaned up after each feature execution  
- ✅ Worker processes can now exit properly, preventing the infinite GC loop issue
- ✅ Zero breaking changes - existing user code works without modifications
- ✅ Intelligent warning system to detect legacy usage patterns

### Technical Implementation
- Introduced `StepRegistry.createFeatureScoped()` and `HookRegistry.createFeatureScoped()`
- CodeGenerator creates feature-scoped registries via `__setCurrentFeatureContext__()`
- Legacy global singleton mode still supported for backward compatibility
- Comprehensive test coverage for isolation and warning systems

## User Impact

**Zero Migration Required:**
```bash
# Users only need to update the package
pnpm update @deepracticex/vitest-cucumber
```

- Step definitions (`Given/When/Then`) work exactly as before
- No configuration changes required
- No code changes needed

## Testing

- ✅ All 76 tests passing (54 in vitest-cucumber, 22 in vitest-cucumber-plugin)
- ✅ New test suites for feature-scoped registry (8 tests)
- ✅ New test suites for warning system (15 tests)
- ✅ All existing tests updated and passing

## Fixes

Closes #16

## Changeset

A changeset has been included explaining the changes for the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>